### PR TITLE
Fix broken links

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,1 +1,1 @@
-github: [hkgnp]
+github: [benjypng]

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ For Citation Key, Author and Page Name templates, use only the stated placeholde
 
 If you find this plugin useful, consider supporting the developer:
 
-- [:gift_heart: Sponsor this project on Github](https://github.com/sponsors/hkgnp)
+- [:gift_heart: Sponsor this project on Github](https://github.com/sponsors/benjypng)
 - [:coffee: Buy me a coffee](https://www.buymeacoffee.com/hkgnp.dev)
 
 ## Issues and Contributions
 
-For bug reports, feature requests, or contributions, please visit the [GitHub repository](https://github.com/hkgnp/logseq-zotero-plugin).
+For bug reports, feature requests, or contributions, please visit the [GitHub repository](https://github.com/benjypng/logseq-zoterolocal-plugin).
 
 *Note: This repository is currently not taking in any pull requests.*
 


### PR DESCRIPTION
The links in the Readme and also in the Logseq Plugin page are outdated and referenced to hkgnp.