### PR TITLE
Add linked_file support and built-in style zotero:// links

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -198,6 +198,10 @@ export type AttachmentItem =
   | ({
       linkMode: 'imported_file'
     } & FileItem)
+  | ({
+    linkMode: 'imported_url'
+    } & FileItem)
+    
 
 export interface CollectionItem {
   key: string

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -67,6 +67,7 @@ export interface ZotItem {
     contentType?: string
     charset?: string
     filename?: string
+    path?: string
     mtime?: number
     md5?: string
     tags: TagItem[]
@@ -179,29 +180,30 @@ export interface ZotData {
   notes: NoteItem[]
 }
 
-export interface URLItem {
-  title: string
+export interface LinkedUrlItem {
   url: string
 }
 
-export interface FileItem {
-  href: string
-  length: number
-  title: string
-  type: string
+export interface LinkedFileItem {
+  path: string
 }
 
-export type AttachmentItem =
-  | ({
-      linkMode: 'linked_url'
-    } & URLItem)
-  | ({
-      linkMode: 'imported_file'
-    } & FileItem)
-  | ({
-    linkMode: 'imported_url'
-    } & FileItem)
-    
+export interface ImportedItem {
+  href: string
+  length: number
+  type: string
+  filename: string
+}
+
+export type AttachmentItem = {
+    title: string
+    library: string
+    key: string
+  } & (
+    | ({ linkMode: 'linked_url'} & LinkedUrlItem)
+    | ({ linkMode: 'linked_file' } & LinkedFileItem)
+    | ({ linkMode: 'imported_url' | 'imported_file' } & ImportedItem)
+  )
 
 export interface CollectionItem {
   key: string

--- a/src/services/map-items.ts
+++ b/src/services/map-items.ts
@@ -35,38 +35,60 @@ export const mapItems = async (
     // Map attachment
     for (const noteAttachment of noteAttachmentItems) {
       // itemType: 'attachment'
-
-      // linkMode: 'imported_file'
-      if (
-        noteAttachment.data.itemType === 'attachment' &&
-        noteAttachment.data.parentItem === item.key &&
-        (noteAttachment.data.linkMode === 'imported_file' || noteAttachment.data.linkMode === 'imported_url' ) &&
-        noteAttachment.links.enclosure
-      ) {
-        item.attachments.push({
-          linkMode: noteAttachment.data.linkMode,
-          ...noteAttachment.links.enclosure,
-        })
-      }
-
-      // linkMode: 'linked_url'
-      if (
-        noteAttachment.data.itemType === 'attachment' &&
-        noteAttachment.data.parentItem === item.key &&
-        noteAttachment.data.linkMode === 'linked_url' &&
-        noteAttachment.data.url
-      ) {
-        item.attachments.push({
-          linkMode: 'linked_url',
+      if (noteAttachment.data.itemType === 'attachment' && noteAttachment.data.parentItem === item.key) {
+        const attachment = {
           title: noteAttachment.data.title,
-          url: noteAttachment.data.url,
-        })
+          library: noteAttachment.library.type === 'user' ? 'library' : `groups/${noteAttachment.library.id}`,
+          key: noteAttachment.data.key
+        }
+        
+        // linkMode: 'imported_file' or 'imported_url'
+        if (
+          (noteAttachment.data.linkMode === 'imported_file' || noteAttachment.data.linkMode === 'imported_url' ) &&
+          noteAttachment.links.enclosure && noteAttachment.data.filename
+        ) {
+          item.attachments.push({
+            ...attachment,
+            linkMode: noteAttachment.data.linkMode,
+            ...noteAttachment.links.enclosure,
+            filename: noteAttachment.data.filename
+          })
+        }
+
+        // linkMode: 'linked_url'
+        else if (
+          noteAttachment.data.linkMode === 'linked_url' &&
+          noteAttachment.data.url
+        ) {
+          item.attachments.push({
+            ...attachment,
+            linkMode: 'linked_url',
+            title: noteAttachment.data.title,
+            url: noteAttachment.data.url,
+          })
+        }
+
+        // linkMode: 'linked_file'
+        else if (
+          noteAttachment.data.linkMode === 'linked_file' &&
+          noteAttachment.data.path
+        ) {
+          item.attachments.push({
+            ...attachment,
+            linkMode: 'linked_file',
+            title: noteAttachment.data.title,
+            path: 
+              noteAttachment.data.path.startsWith('attachments:') 
+                ? noteAttachment.data.path.substring('attachments:'.length) 
+                : noteAttachment.data.path
+          })
+        }
       }
 
       // itemType: 'note'
-      if (
-        noteAttachment.data.parentItem === item.key &&
+      else if (
         noteAttachment.data.itemType === 'note' &&
+        noteAttachment.data.parentItem === item.key &&
         noteAttachment.data.note
       ) {
         item.notes.push({ note: noteAttachment.data.note })

--- a/src/services/map-items.ts
+++ b/src/services/map-items.ts
@@ -40,11 +40,11 @@ export const mapItems = async (
       if (
         noteAttachment.data.itemType === 'attachment' &&
         noteAttachment.data.parentItem === item.key &&
-        noteAttachment.data.linkMode === 'imported_file' &&
+        (noteAttachment.data.linkMode === 'imported_file' || noteAttachment.data.linkMode === 'imported_url' ) &&
         noteAttachment.links.enclosure
       ) {
         item.attachments.push({
-          linkMode: 'imported_file',
+          linkMode: noteAttachment.data.linkMode,
           ...noteAttachment.links.enclosure,
         })
       }

--- a/src/services/replace-template-with-values.ts
+++ b/src/services/replace-template-with-values.ts
@@ -1,11 +1,11 @@
 import { format, parse, parseISO } from 'date-fns'
 
-import { CollectionItem, CreatorItem, NoteItem, ZotData } from '../interfaces'
+import { AttachmentItem, CollectionItem, CreatorItem, NoteItem, ZotData } from '../interfaces'
 import { getCollectionNames } from './get-collection-names'
 
 export const replaceTemplateWithValues = async (
   template: string,
-  data: ZotData | CreatorItem,
+  data: ZotData | CreatorItem | AttachmentItem,
   collections?: CollectionItem[],
 ) => {
   const keys = Object.keys(data)
@@ -50,19 +50,42 @@ export const replaceTemplateWithValues = async (
       }
     } else if (key === 'attachments') {
       const attachmentArr = []
-      for (const attachment of value) {
+      for (const attachment of value as AttachmentItem[]) {
         let str
-        if (attachment.linkMode === 'linked_url') {
-          str = `[${encodeURIComponent(attachment.title)}](${attachment.url})`
-        }
-
-        if (attachment.linkMode === 'imported_file' || attachment.linkMode === 'imported_url') {
-          str = await replaceTemplateWithValues(
-            attachment.type === 'application/pdf'
-              ? `![${encodeURIComponent(attachment.title)}](${attachment.href})`
-              : `[${encodeURIComponent(attachment.title)}](${attachment.href})`,
-            attachment,
-          )
+        // Use zotero://select links to open items through Zotero, including the
+        // file macros used by the built-in Zotero integration
+        if (logseq.settings!.useZoteroLinks) {
+          const zoteroLink = `zotero://select/${attachment.library}/items/${attachment.key}`
+          switch (attachment.linkMode) {
+            case 'linked_url':
+              str = `[${attachment.title}](${attachment.url})`
+              break
+            case 'linked_file':
+              str = `[${attachment.title}](${zoteroLink}) {{zotero-linked-file "${attachment.path}"}}`
+              break
+            case 'imported_file':
+            case 'imported_url':
+              str = `[${attachment.title}](${zoteroLink}) {{zotero-imported-file ${attachment.key}, "${attachment.filename}"}}`
+              break
+          }
+        // Use standard file system links to items
+        } else {
+          switch (attachment.linkMode) {
+            case 'linked_url':
+              str = `[${encodeURIComponent(attachment.title)}](${attachment.url})`
+              break
+            case 'linked_file':
+              str = `[${encodeURIComponent(attachment.title)}](${logseq.settings!.linkedAttachmentBasePath}/${attachment.path})`
+              break
+            case 'imported_file':
+            case 'imported_url':
+              str = await replaceTemplateWithValues(
+                attachment.type === 'application/pdf'
+                  ? `![${encodeURIComponent(attachment.title)}](${attachment.href})`
+                  : `[${encodeURIComponent(attachment.title)}](${attachment.href})`,
+                attachment,
+              )
+          }
         }
 
         attachmentArr.push(str)

--- a/src/services/replace-template-with-values.ts
+++ b/src/services/replace-template-with-values.ts
@@ -56,7 +56,7 @@ export const replaceTemplateWithValues = async (
           str = `[${encodeURIComponent(attachment.title)}](${attachment.url})`
         }
 
-        if (attachment.linkMode === 'imported_file') {
+        if (attachment.linkMode === 'imported_file' || attachment.linkMode === 'imported_url') {
           str = await replaceTemplateWithValues(
             attachment.type === 'application/pdf'
               ? `![${encodeURIComponent(attachment.title)}](${attachment.href})`

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -49,6 +49,20 @@ export const handleSettings = async ({
         description: `Specify the template when using the command /Zotero: Insert citation. Ensure that <% citeKey %> placeholder is indicated in your template`,
         default: '[@<% citeKey %>]',
       },
+      {
+        key: 'useZoteroLinks',
+        type: 'boolean',
+        title: 'Use Zotero Links',
+        description: 'Use zotero:// links for attachments, instead of local file links',
+        default: false
+      },
+      {
+        key: 'linkedAttachmentBasePath',
+        type: 'string',
+        title: 'Linked Attachment Base Directory',
+        description: `Base directory for linked attachments. Should be the same value as the option in Zotero (under Settings > Advanced). This is not used if the 'Use Zotero Links' option is enabled`,
+        default: ''
+      }
     ]
 
     settings = [...settings, ...pluginSettings]


### PR DESCRIPTION
This builds on #32 by @JosuaCarl to (hopefully) fix all cases that could lead to #25.

- `imported_url` is handled basically the same as `imported_file`, just like in #32. I moved things around a little to make things more coherent with the other changes, but it should still work the same in principle.
- `linked_file` is also handled. This enables the [zotmoov](https://github.com/wileyyugioh/zotmoov) workflow where files are stored in a separate folder.

The `linked_file` mode is slightly different from the others, because it does not include the full file path, but instead relies on Zotero's *Linked Attachment Base Directory* option. To deal with this, I added two settings:

- `linkedAttachmentBasePath` to set the path of this directory, which is then used to create absolute file paths
- `useZoteroLinks`, which creates links to Zotero (using the zotero://select handler) rather than to the file itself, accompanied with a `{{zotero-linked-file ...}}` or `{{zotero-imported-file ...}}` macro to open the file directly within Logseq. This is similar to the built-in Zotero integration in Logseq and relies on its settings to find the correct files with those macros.