### PR TITLE
Add support for imported_url, linked_file and improve support for inline attachments

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -134,6 +134,7 @@ export const ZOT_DATA_KEY_MAP = {
   pages: true,
   parentItem: true,
   patentNumber: true,
+  path: true,
   place: true,
   postType: true,
   presentationType: true,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -223,6 +223,7 @@ export type ZotData = Omit<ZotItem['data'], 'code' | 'note'> & {
 }
 
 export interface URLItem {
+  contentType: string
   title: string
   url: string
 }
@@ -234,13 +235,22 @@ export interface FileItem {
   type: string
 }
 
+export interface LinkedFileItem {
+  contentType: string
+  path: string
+  title: string
+}
+
 export type AttachmentItem =
   | ({
       linkMode: 'linked_url'
     } & URLItem)
   | ({
-      linkMode: 'imported_file'
+      linkMode: 'imported_file' | 'imported_url'
     } & FileItem)
+  | ({
+      linkMode: 'linked_file'
+    } & LinkedFileItem)
 
 export interface CollectionItem {
   key: string

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -40,7 +40,7 @@ export interface ZotItem {
       href: string
       type: string
       title: string
-      length: number
+      length?: number
     }
   }
   meta: {
@@ -126,6 +126,7 @@ export interface ZotItem {
     pages?: string
     parentItem?: string
     patentNumber?: string
+    path?: string
     place?: string
     postType?: string
     presentationType?: string
@@ -228,7 +229,7 @@ export interface URLItem {
 
 export interface FileItem {
   href: string
-  length: number
+  length?: number
   title: string
   type: string
 }

--- a/src/services/handle-zot-db.ts
+++ b/src/services/handle-zot-db.ts
@@ -171,13 +171,28 @@ export const handleZotInDb = async (zotItem: ZotData, pageName: string) => {
   // Insert attachment
   if (zotItem.attachments && zotItem.attachments.length > 0) {
     const attachmentChildBlks = zotItem.attachments.map((attachment) => {
+      const inlineModifier = (contentType: string) =>
+        logseq.settings?.openAttachmentInline &&
+        (contentType === 'application/pdf' ||
+        contentType === 'image/png' ||
+        contentType === 'image/jpg' ||
+        contentType === 'image/jpeg' ||
+        contentType === 'image/gif' ||
+        contentType === 'image/webp' ||
+        contentType === 'image/svg+xml')
+          ? '!' : ''
+
       if (attachment.linkMode === 'linked_url') {
         return {
-          content: `${logseq.settings?.openAttachmentInline ? '!' : ''}[${attachment.title}](${decodeURI(attachment.url)})`,
+          content: `${inlineModifier(attachment.contentType)}[${attachment.title}](${decodeURI(attachment.url)})`,
+        }
+      } else if (attachment.linkMode === 'linked_file') {
+        return {
+          content: `${inlineModifier(attachment.contentType)}[${attachment.title}](file://${decodeURI(attachment.path)})`,
         }
       } else {
         return {
-          content: `${logseq.settings?.openAttachmentInline ? '!' : ''}[${attachment.title}](${decodeURI(attachment.href)})`,
+          content: `${inlineModifier(attachment.type)}[${attachment.title}](${decodeURI(attachment.href)})`,
         }
       }
     })

--- a/src/services/map-items.ts
+++ b/src/services/map-items.ts
@@ -60,12 +60,24 @@ export const mapItems = async (
          ITEM TYPE == ATTACHMENT
          */
         if (
-          noteAndAttachment.data.linkMode === 'imported_file' &&
+          (noteAndAttachment.data.linkMode === 'imported_file' ||
+            noteAndAttachment.data.linkMode === 'imported_url') &&
           noteAndAttachment.links.enclosure
         ) {
           item.attachments.push({
             linkMode: 'imported_file',
             ...noteAndAttachment.links.enclosure,
+          })
+        } else if (
+          noteAndAttachment.data.linkMode === 'linked_file' &&
+          noteAndAttachment.data.path &&
+          noteAndAttachment.data.contentType !== undefined
+        ) {
+          item.attachments.push({
+            linkMode: 'linked_file',
+            contentType: noteAndAttachment.data.contentType,
+            path: noteAndAttachment.data.path,
+            title: noteAndAttachment.data.title,
           })
         } else if (
           noteAndAttachment.data.linkMode === 'linked_url' &&
@@ -75,6 +87,8 @@ export const mapItems = async (
             linkMode: 'linked_url',
             title: noteAndAttachment.data.title,
             url: noteAndAttachment.data.url,
+            // every url has a contentType, added for type safety
+            contentType: noteAndAttachment.data.contentType ?? '',
           })
         }
       } else if (

--- a/src/services/replace-template-with-values.ts
+++ b/src/services/replace-template-with-values.ts
@@ -54,13 +54,21 @@ export const replaceTemplateWithValues = async (
         let str
         if (attachment.linkMode === 'linked_url') {
           str = `[${encodeURIComponent(attachment.title)}](${attachment.url})`
-        }
-
-        if (attachment.linkMode === 'imported_file') {
+        } else if (
+          attachment.linkMode === 'imported_file' ||
+          attachment.linkMode === 'imported_url'
+        ) {
           str = await replaceTemplateWithValues(
             attachment.type === 'application/pdf'
               ? `![${encodeURIComponent(attachment.title)}](${attachment.href})`
               : `[${encodeURIComponent(attachment.title)}](${attachment.href})`,
+            attachment,
+          )
+        } else if (attachment.linkMode === 'linked_file') {
+          str = await replaceTemplateWithValues(
+            attachment.contentType === 'application/pdf' ?
+              `![${encodeURIComponent(attachment.title)}](file://${attachment.path})` :
+              `[${encodeURIComponent(attachment.title)}](file://${attachment.path})`,
             attachment,
           )
         }


### PR DESCRIPTION
I added support for all types of attachments that occur in Zotero (this is the only place where they are mentioned in the [official documentation](https://www.zotero.org/support/dev/web_api/v3/file_upload)).
This combines the features of #32 and #38. So this correctly handles
- `imported_file` (already implemented)
- `imported_url` (files, that are downloaded from the web, but locally stored, mostly usinig the Browser Extension)
- `linked_url` (also already partially implemented, but I added support for content type and more complex URL which are possible to occur)
- `linked_file` (files, that are not stored within Zotero, but where a link in the local filesystem exists)

For each of this types, Zotero stores the `Content-Type` of the attachment. In the settings, we already have the option whether links should be handled inside (inline) Logseq or outside. Currently, when enabled, the plugin tries to handle **all types** of files within Logseq, which does not work. For example, linked Latex documents can't be handled by Logseq and errors occur.
This pull request adds checks for the Content-Type and only inlines supported files.

I am not sure why the previous pull request did not get merged, because for me the addressed issues affect more than 50% of all my entries in Zotero. So if you need any further examples or debug logs of the JSON provided by the API, feel free to request this.

In the end I just want to say thank you for the really great plugin and all your efforts to already port it to the DB version!