### PR TITLE
Fix user agent #61

### DIFF
--- a/src/services/get-zot-items.ts
+++ b/src/services/get-zot-items.ts
@@ -15,6 +15,7 @@ const api = wretch().url(ZOT_URL).headers({
   'Content-Type': 'application/json',
   'x-zotero-connector-api-version': '3.0',
   'zotero-allowed-request': 'true',
+  'User-Agent': 'curl/7.45.1',
 })
 
 export const testZotConnection = async (): Promise<{

--- a/src/services/get-zot-items.ts
+++ b/src/services/get-zot-items.ts
@@ -30,14 +30,14 @@ export const testZotConnection = async (): Promise<{
 
     const wretchError = error as WretchError
     logseq.UI.showMsg(
-      `❌ logseq-zoteroloca-plugin: Connection error
+      `❌ logseq-zoterolocal-plugin: Connection error
 Status: ${wretchError.status}
 Response: ${wretchError.message}`,
       'error',
     )
     return {
       code: 'error',
-      msg: `❌ logseq-zoteroloca-plugin: Connection error
+      msg: `❌ logseq-zoterolocal-plugin: Connection error
 Status: ${wretchError.status}
 Response: ${wretchError.message}`,
     }


### PR DESCRIPTION
In Zotero 9, you need to supply a non-browser User Agent to enable connections; otherwise, a forbidden 403 error occurs. To solve this issue, we supply a generic curl user agent.

Closes #61 